### PR TITLE
Init subscriber with a state

### DIFF
--- a/Sources/Shared/Subscriber.swift
+++ b/Sources/Shared/Subscriber.swift
@@ -5,10 +5,11 @@ public class Subscriber<T: StateType>: StoreSubscriber {
   public typealias StoreSubscriberStateType = T
 
   weak var store: Store<T>?
-  public let state: Variable<T?> = Variable(nil)
+  public let state: Variable<T>
 
-  public init(store: Store<T>) {
+  public init(store: Store<T>, state: T) {
     self.store = store
+    self.state = Variable(state)
     store.subscribe(self)
   }
 


### PR DESCRIPTION
I think it's easier to have non optional state when you subscribe to state updates with RxSwift. Otherwise I have to unwrap all the time. And ideally we should have initial state that we can use to instantiate subscriber. What do you think?